### PR TITLE
update labels to look for after deploying the prometheus adapter

### DIFF
--- a/EnvironmentSetup/AWS/Source/setup
+++ b/EnvironmentSetup/AWS/Source/setup
@@ -679,7 +679,7 @@ custommetricsSetup()
 	helm repo update >> $LOG_PATH
 	helm install was -f values.yaml prometheus-community/prometheus-adapter --namespace monitoring >> $LOG_PATH
 	sleep 15
-	kubectl wait --for=condition=ready --timeout=30m pod -l app=prometheus-adapter -n monitoring >> $LOG_PATH
+	kubectl wait --for=condition=ready --timeout=30m pod -l app.kubernetes.io/name=prometheus-adapter -n monitoring >> $LOG_PATH
 }
 
 deploymentStatus()

--- a/EnvironmentSetup/Azure/Source/setup
+++ b/EnvironmentSetup/Azure/Source/setup
@@ -639,7 +639,7 @@ custommetricsSetup()
 	helm repo update >> $LOG_PATH
 	helm install was -f values.yaml prometheus-community/prometheus-adapter --namespace monitoring >> $LOG_PATH
 	sleep 15
-	kubectl wait --for=condition=ready --timeout=30m pod -l app=prometheus-adapter -n monitoring >> $LOG_PATH
+	kubectl wait --for=condition=ready --timeout=30m pod -l app.kubernetes.io/name=prometheus-adapter -n monitoring >> $LOG_PATH
 }
 
 


### PR DESCRIPTION
With v3 of the prometheus-adapter charts, the `app=prometheus-adapter` label is no longer being added; updating the label.