### PR TITLE
Decrease aws-setup-manager kubectl version to v1.23.0

### DIFF
--- a/EnvironmentSetup/AWS/Source/Dockerfile
+++ b/EnvironmentSetup/AWS/Source/Dockerfile
@@ -7,7 +7,7 @@ ENV TF_DATA_DIR=/terraform-state
 RUN apt-get update && apt-get install awscli software-properties-common apt-transport-https locales curl tar git procps libncurses-dev -y && \
 	locale-gen en_US.utf8 && locale -a  && \
 	update-locale LANG=en_US.UTF-8 LANG=en_US.UTF8 LC_CTYPE=en_US.UTF8 LC_COLLATE=en_US.UTF8 && \
-	curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
+	curl -LO "https://dl.k8s.io/release/v1.23.0/bin/linux/amd64/kubectl" && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl  && \
     kubectl version --client  && \

--- a/EnvironmentSetup/AWS/Source/Dockerfile
+++ b/EnvironmentSetup/AWS/Source/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:focal
+ENV KUBECTL_VERSION='v1.23.0'
 ENV DEBIAN_FRONTEND=noninteractive 
 ENV TERM xterm-256color
 ENV COLORTERM truecolor
@@ -7,7 +8,7 @@ ENV TF_DATA_DIR=/terraform-state
 RUN apt-get update && apt-get install awscli software-properties-common apt-transport-https locales curl tar git procps libncurses-dev -y && \
 	locale-gen en_US.utf8 && locale -a  && \
 	update-locale LANG=en_US.UTF-8 LANG=en_US.UTF8 LC_CTYPE=en_US.UTF8 LC_COLLATE=en_US.UTF8 && \
-	curl -LO "https://dl.k8s.io/release/v1.23.0/bin/linux/amd64/kubectl" && \
+	curl -LO "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl  && \
     kubectl version --client  && \


### PR DESCRIPTION
Currently, the Kubernetes cluster version is v1.20 on terraform/variables.tf

https://github.com/WolframResearch/WAS-Kubernetes/blob/d16d0eac09689986cc8c9b54add3532a478a77b4/EnvironmentSetup/AWS/Source/terraform/variables.tf#L10

But in Dockerfile, it downloads the latest stable kubectl for aws-setup-manager.(v1.24.0)
https://github.com/WolframResearch/WAS-Kubernetes/blob/03b8d2fd84d01644116bca7050769fcad82d9f74/EnvironmentSetup/AWS/Source/Dockerfile#L10

So it occurs a huge version difference between kubectl client version and the cluster version.
It breaks the installation script.
```
Spin pid is: 772019
error: exec plugin: invalid apiVersion "client.authentication.k8s.io/v1alpha1"
Setup Ingress Controller: [2022-05-17 19:41:23 UTC] [ERROR] Failed with error: 1
[2022-05-17 19:41:23 UTC] [ERROR] Something went wrong. Exiting.
[2022-05-17 19:41:23 UTC] [ERROR] The last few log entries were:
```

I changed the Dockerfile to download kubectl v1.23.0 for aws-setup-manager.