### PR TITLE
[WAS-515] - Fix connection refused error on Building EKS stage

### DIFF
--- a/EnvironmentSetup/AWS/Source/terraform/main.tf
+++ b/EnvironmentSetup/AWS/Source/terraform/main.tf
@@ -73,6 +73,7 @@ module "eks" {
   subnets                   = module.vpc.private_subnets
   vpc_id                    = module.vpc.vpc_id
   write_kubeconfig          = false
+  cluster_create_timeout    = "120m"
   
   tags = {
     Environment = "Wolfram Application Server"


### PR DESCRIPTION
It seems it is related to the timeout configuration. Sometimes EKS cluster creation takes more than ~30mins to live. (It is related to AWS itself). When Terraform checks for the health of EKS, it breaks. 

I increased the timeout from 30 minutes(default) to 120 minutes.

https://registry.terraform.io/modules/terraform-aws-modules/eks/aws/16.1.0?tab=inputs

![Screenshot from 2022-10-27 11-02-30](https://user-images.githubusercontent.com/105753786/198341053-4c8028c2-8a3f-449c-aba4-d83e665e1dcf.png)

