### PR TITLE
[WAS-520] Added platform 

### DIFF
--- a/EnvironmentSetup/AWS/docker-compose.yml
+++ b/EnvironmentSetup/AWS/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.8'
 
 services:
   aws-setup-manager:
+    platform: linux/amd64
     build:
       context: Source
       dockerfile: Dockerfile

--- a/EnvironmentSetup/Azure/docker-compose.yml
+++ b/EnvironmentSetup/Azure/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.8'
 
 services:
   azure-setup-manager:
+    platform: linux/amd64
     build:
       context: Source
       dockerfile: Dockerfile


### PR DESCRIPTION
Previously, when we try to `docker-compose up` with Apple processors, Dockerfile returned error on `echo "deb [arch=amd64] https://apt.releases.hashicorp.com focal main" | tee /etc/apt/sources.list && \` step.
With `platform`, we specified the linux/amd64 architecture to use when building the image.

For more information: https://docs.docker.com/compose/compose-file/compose-file-v2/#platform