### PR TITLE
[WAS-525] Upgraded AKS kubernetes version to 1.23

### DIFF
--- a/EnvironmentSetup/Azure/Source/hpa/active-web-elements-server-hpa-autoscaler.yaml
+++ b/EnvironmentSetup/Azure/Source/hpa/active-web-elements-server-hpa-autoscaler.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
  name: active-web-elements-server-hpa

--- a/EnvironmentSetup/Azure/Source/hpa/endpoint-manager-hpa-autoscaler.yaml
+++ b/EnvironmentSetup/Azure/Source/hpa/endpoint-manager-hpa-autoscaler.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
  name: endpoint-manager-hpa

--- a/EnvironmentSetup/Azure/Source/hpa/minio-hpa-autoscaler.yaml
+++ b/EnvironmentSetup/Azure/Source/hpa/minio-hpa-autoscaler.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
  name: minio-hpa

--- a/EnvironmentSetup/Azure/Source/hpa/resource-manager-hpa-autoscaler.yaml
+++ b/EnvironmentSetup/Azure/Source/hpa/resource-manager-hpa-autoscaler.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
  name: resource-manager-hpa

--- a/EnvironmentSetup/Azure/Source/setup
+++ b/EnvironmentSetup/Azure/Source/setup
@@ -997,7 +997,7 @@ DeleteFunction() {
   log_debug "Phase 5 of 5: Cleanup"
   printf "${GREEN}☑☑☑☑${YELLOW}☑${NORMAL} Phase ${YELLOW}5${NORMAL} of ${GREEN}5${NORMAL}: Cleanup\\n"
 
-  sed -i -e "s~$BASE_URL~domain.com~g" deployments/active-web-elements-server-deployment.yaml
+  sed -i -e "s~$BASE_URL~http://domain.com/~g" deployments/active-web-elements-server-deployment.yaml
 
   sed -i -e "s~^    service.beta.kubernetes.io\/azure-dns-label-name: .*~    service.beta.kubernetes.io\/azure-dns-label-name: \"domain\"~g" ingress-controller/deploy.yml
 

--- a/EnvironmentSetup/Azure/Source/terraform/variables.tf
+++ b/EnvironmentSetup/Azure/Source/terraform/variables.tf
@@ -23,7 +23,7 @@ variable "max_pods" {
 }
 
 variable "cluster-version" {
-  default = "1.22"
+  default = "1.23"
 }
 
 variable "disk-size" {


### PR DESCRIPTION
Previously when I try to test WAS setup script for Azure, it exited with this error message.
```
Building AKS - (can take upto 15 minutes)                               [ERROR] Failed with error: 1
[  ✘  ]

[ERROR] Something went wrong. Exiting.
[ERROR] The last few log entries were:
azurerm_kubernetes_cluster.default: Still creating... [10s elapsed]
╷
│ Error: creating Managed Cluster (Subscription: "XXXX-XXXX-XXXX-XXXX-XXXX"
│ Resource Group Name: "WAS-rg"
│ Resource Name: "WAS-aks"): managedclusters.ManagedClustersClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: Code="UnsupportedAliasMinorVersion" Message="1.22 is not a supported Kubernetes version. To see our supported AKS version list please visit https://docs.microsoft.com/azure/aks/supported-kubernetes-versions?tabs=azure-cli for more details."
│ 
│   with azurerm_kubernetes_cluster.default,
│   on main.tf line 30, in resource "azurerm_kubernetes_cluster" "default":
│   30: resource "azurerm_kubernetes_cluster" "default" {
│ 
╵
Releasing state lock. This may take a few moments...
Building AKS - (can take upto 15 minutes): [2022-12-16 11:41:41 UTC] [ERROR] Failed with error: 1
[2022-12-16 11:41:41 UTC] [ERROR] Something went wrong. Exiting.
[2022-12-16 11:41:41 UTC] [ERROR] The last few log entries were:

```

It seems we need to upgrade our kubernetes cluster version to 1.23.
https://learn.microsoft.com/en-gb/azure/aks/supported-kubernetes-versions?tabs=azure-cli

I applied updates for upgrading 1.22 to 1.23.

Reference: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.23.md#changelog-since-v1220
