### PR TITLE
[WAS-557] - Fix kafka issue

### DIFF
--- a/EnvironmentSetup/Azure/Source/kafka/kafka-persistent.yaml
+++ b/EnvironmentSetup/Azure/Source/kafka/kafka-persistent.yaml
@@ -40,6 +40,7 @@ spec:
         type: persistent-claim
         size: 10Gi
         deleteClaim: false
+        class: was-azurefile
   zookeeper:
     replicas: 3
     jvmOptions:


### PR DESCRIPTION
I faced this error message on kafka-persistent pods in Azure.

```
2023-05-18 17:26:38,658 ERROR Failed to clean up log for nodefile-info-1 in dir /var/lib/kafka/data-0/kafka-log0 due to IOException (kafka.server.LogDirFailureChannel) [kafka-log-cleaner-thread-0]
java.nio.file.NoSuchFileException: /var/lib/kafka/data-0/kafka-log0/nodefile-info-1/00000000000000000000.log.cleaned
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
	at java.base/sun.nio.fs.UnixFileSystemProvider.newFileChannel(UnixFileSystemProvider.java:182)
	at java.base/java.nio.channels.FileChannel.open(FileChannel.java:292)
	at java.base/java.nio.channels.FileChannel.open(FileChannel.java:345)
	at org.apache.kafka.common.record.FileRecords.openChannel(FileRecords.java:465)
	at org.apache.kafka.common.record.FileRecords.open(FileRecords.java:428)
	at org.apache.kafka.common.record.FileRecords.open(FileRecords.java:437)
	at kafka.log.LogSegment$.open(LogSegment.scala:663)
	at kafka.log.LogCleaner$.createNewCleanedSegment(LogCleaner.scala:456)
	at kafka.log.Cleaner.cleanSegments(LogCleaner.scala:566)
	at kafka.log.Cleaner.$anonfun$doClean$6(LogCleaner.scala:538)
	at kafka.log.Cleaner.$anonfun$doClean$6$adapted(LogCleaner.scala:537)
	at scala.collection.immutable.List.foreach(List.scala:431)
	at kafka.log.Cleaner.doClean(LogCleaner.scala:537)
	at kafka.log.Cleaner.clean(LogCleaner.scala:511)
	at kafka.log.LogCleaner$CleanerThread.cleanLog(LogCleaner.scala:380)
	at kafka.log.LogCleaner$CleanerThread.cleanFilthiestLog(LogCleaner.scala:352)
	at kafka.log.LogCleaner$CleanerThread.tryCleanFilthiestLog(LogCleaner.scala:332)
	at kafka.log.LogCleaner$CleanerThread.doWork(LogCleaner.scala:321)
	at kafka.utils.ShutdownableThread.run(ShutdownableThread.scala:96)

```

It looks like there is a permission issue. I added was-azurefile storageclass in strimzi kafka volume configuration.