### PR TITLE
[WAS-558] - WAS Service Connect Fails on AWS

### DIFF
--- a/EnvironmentSetup/AWS/Source/deployments/active-web-elements-server-deployment.yaml
+++ b/EnvironmentSetup/AWS/Source/deployments/active-web-elements-server-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - name: applicationserver.nodefiles.cachedirectory
           value: /opt/.wolframcache/nodefiles/
         - name: applicationserver.version
-          value: "3.3.1"
+          value: "3.3.2"
         - name: applicationserver.wolframEngineVersion
           value: "13.2.0"
         - name: applicationserver.kernelinitializationfile.name

--- a/EnvironmentSetup/AWS/Source/setup
+++ b/EnvironmentSetup/AWS/Source/setup
@@ -783,7 +783,7 @@ EOF
 
   # AWES deployment setup
   BASE_URL=$(kubectl get svc -n ingress-nginx | awk '{print $4}' | sed -n '2p')
-  sed -i -e "s~$BASE_URL~domain.com~g" deployments/active-web-elements-server-deployment.yaml
+  sed -i -e "s~domain.com~$BASE_URL~g" deployments/active-web-elements-server-deployment.yaml
 
   run_ok "kubectl apply -f deployments/" "Setup Deployments"
   run_ok "deploymentStatus" "Waiting for Deployments To Be Ready"

--- a/EnvironmentSetup/Azure/Source/deployments/active-web-elements-server-deployment.yaml
+++ b/EnvironmentSetup/Azure/Source/deployments/active-web-elements-server-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         - name: applicationserver.nodefiles.cachedirectory
           value: /opt/.wolframcache/nodefiles/
         - name: applicationserver.version
-          value: "3.3.1"
+          value: "3.3.2"
         - name: applicationserver.wolframEngineVersion
           value: "13.2.0"
         - name: applicationserver.kernelinitializationfile.name


### PR DESCRIPTION
When we deployed WAS on AWS and tried to do ServiceConnect, it returned
```
 ServiceConnect::invcfg: Wolfram Application Server is incorrectly configured. Please contact technical support for assistance.
```

I checked `/.applicationserver/info`, it returned this JSON file.
```
{
    "resourceManager": "http://domain.com/resources/",
    "endpointManager": "http://domain.com/endpoints/",
    "nodefileManager": "http://domain.com/nodefiles/",
    "canonicalBaseURL": "http://domain.com/",
    "restartURL": "http://domain.com/.applicationserver/kernel/restart",
    "wasVersion": "3.3.1",
    "wolframEngineVersion": "13.2.0"
}
```

There was a typo in `sed` command, I fixed that and the issue is resolved.