### PR TITLE
improve the ingress /.applicationserver/kernel/restart path

### DIFF
--- a/EnvironmentSetup/AWS/Source/ingress/was-ingress-awes-service.yml
+++ b/EnvironmentSetup/AWS/Source/ingress/was-ingress-awes-service.yml
@@ -46,7 +46,7 @@ spec:
   rules:
   - http:
       paths:
-        - path: /.applicationserver/kernel/restart
+        - path: /\.applicationserver/kernel/restart
           pathType: ImplementationSpecific
           backend:
             service:

--- a/EnvironmentSetup/Azure/Source/ingress/was-ingress-awes-service.yml
+++ b/EnvironmentSetup/Azure/Source/ingress/was-ingress-awes-service.yml
@@ -46,7 +46,7 @@ spec:
   rules:
   - http:
       paths:
-        - path: /.applicationserver/kernel/restart
+        - path: /\.applicationserver/kernel/restart
           pathType: Prefix
           backend:
             service:


### PR DESCRIPTION
which is a regex, so an escape is needed to match only a literal '.'.